### PR TITLE
Bump version :arrow_up: 1.0.0

### DIFF
--- a/lib/is_an/version.rb
+++ b/lib/is_an/version.rb
@@ -1,3 +1,3 @@
 module IsAn
-  VERSION = '0.0.2'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
This is primarily because the public API has been completed for this gem. (Yes, there is literally one method alias in the entire Gem, but still.)
